### PR TITLE
Allow blanks in group names 

### DIFF
--- a/oscm-common/src/main/java/org/oscm/identity/IdentityClient.java
+++ b/oscm-common/src/main/java/org/oscm/identity/IdentityClient.java
@@ -9,10 +9,9 @@
  */
 package org.oscm.identity;
 
-import org.oscm.identity.exception.IdentityClientException;
-import org.oscm.identity.model.*;
-import org.oscm.identity.validator.IdentityValidator;
-import org.oscm.validation.ArgumentValidator;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -21,9 +20,17 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import org.oscm.identity.exception.IdentityClientException;
+import org.oscm.identity.model.AccessType;
+import org.oscm.identity.model.Credentials;
+import org.oscm.identity.model.GroupInfo;
+import org.oscm.identity.model.IdToken;
+import org.oscm.identity.model.TokenDetails;
+import org.oscm.identity.model.TokenType;
+import org.oscm.identity.model.UserId;
+import org.oscm.identity.model.UserInfo;
+import org.oscm.identity.validator.IdentityValidator;
+import org.oscm.validation.ArgumentValidator;
 
 /** Abstract client for accessing oscm-identity endpoints */
 public abstract class IdentityClient {
@@ -119,25 +126,31 @@ public abstract class IdentityClient {
     }
 
   /**
-   * Searches for calls the API endpoint that will search for existing group with the name equal to
-   * the name of the one passed in GroupInfo object and returns it if possible
+   * Search the existing group with the name equal to the given group name and
+   * return detailed information of this group.
    *
-   * @param builder endpoint url builder
-   * @param client client instance
-   * @param groupInfo Group Info wrapper that contains the data about group that is about to be
-   *     created
-   * @param accessToken IDP access token
+   * @param builder
+   *          - an endpoint URL builder
+   * @param client
+   *          - a client instance
+   * @param groupName
+   *          - - the name of the group that is about to be created
+   * @param accessToken
+   *          - required IDP access token
    * @return representation of existing group which creation was requested
    * @throws IdentityClientException
+   *           - if a group with the given name could not be found or any other
+   *           problem occurred on retrieving the requested information.
    */
   private GroupInfo getExistingGroup(
-      IdentityUrlBuilder builder, Client client, String groupInfo, String accessToken)
+      IdentityUrlBuilder builder, Client client, String groupName, String accessToken)
       throws IdentityClientException {
     String url = builder.buildCreateGroupUrl();
+    String path = builder.buildGroupPath(groupName);
     Response response =
         client
             .target(url)
-            .path(OSCM_PREFIX + groupInfo)
+            .path(path)
             .request(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
             .get();

--- a/oscm-common/src/main/java/org/oscm/identity/IdentityUrlBuilder.java
+++ b/oscm-common/src/main/java/org/oscm/identity/IdentityUrlBuilder.java
@@ -7,6 +7,11 @@
  *******************************************************************************/
 package org.oscm.identity;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import org.oscm.identity.exception.IdentityClientException;
+
 /** Class responsible for building oscm-identity related endpoints */
 public class IdentityUrlBuilder {
 
@@ -19,6 +24,7 @@ public class IdentityUrlBuilder {
   private static String RESOURCE_USERS = "users";
   private static String RESOURCE_GROUPS = "groups";
   private static String RESOURCE_TOKEN = "token";
+  private static final String OSCM_PREFIX = "OSCM_";
 
   private String tenantId;
 
@@ -114,6 +120,22 @@ public class IdentityUrlBuilder {
             .toString();
 
     return url;
+  }
+  
+  /**
+   * Builds an URL encoded path from given group name
+   * 
+   * @param groupName - the group name to be encoded
+   * @return the URL encoded path
+   */
+  public String buildGroupPath(String groupName) throws IdentityClientException {
+    String path = new StringBuilder(OSCM_PREFIX)
+            .append(groupName).toString();
+    try {
+      return URLEncoder.encode(path, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IdentityClientException(e.getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
* Use URL encoded path for group names
* Note: This PR depends on https://github.com/servicecatalog/oscm-identity/pull/70 (to be merged first)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-commons/26)
<!-- Reviewable:end -->
